### PR TITLE
inject ace theme styles to element

### DIFF
--- a/src/juicy-ace-editor.html
+++ b/src/juicy-ace-editor.html
@@ -64,6 +64,13 @@
 
 
         var editor = this.editor || ace.edit(container);
+
+        // inject base editor styles
+        this.injectTheme('#ace_editor');
+
+        // handle theme changes
+        editor.renderer.addEventListener("themeLoaded", this.onThemeLoaded.bind(this));
+
         // initial attributes
             editor.setTheme( this.getAttribute("theme") );
             editor.setFontSize( this.getAttribute("fontsize") );
@@ -119,6 +126,26 @@
 
         }
     };
+
+
+    TomalecAceEditorPrototype.onThemeLoaded = function(e){
+        var themeId = "#" + e.theme.cssClass;
+        this.injectTheme(themeId);
+    }
+
+    // inject the style tag of a theme to the element
+    TomalecAceEditorPrototype.injectTheme = function(themeId){
+        var n = document.querySelector(themeId);
+        this.appendChild(cloneStyle(n));
+    }
+
+    //helper function to clone a style
+    function cloneStyle(style) {
+        var s = document.createElement('style');
+        s.id = style.id;
+        s.textContent = style.textContent;
+        return s;
+    }
 
     document.registerElement('juicy-ace-editor', {
         prototype: TomalecAceEditorPrototype


### PR DESCRIPTION
To enable the usage of `juicy-ace-editor` within the definition of custom Polymer elements we need someway to pull `ace`  theme styles to the shadow DOM. With this pull request, a listener is set to detect theme changes and inject the theme's CSS inside the `juicy-ace-editor` element. Btw, we can modify this to inject the styles to the `shadowDom` of the element.
