### PR TITLE
Fix not working fontsize property.

### DIFF
--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -94,7 +94,7 @@
 
         // initial attributes
             editor.setTheme( this.getAttribute("theme") );
-            editor.setFontSize( this.getAttribute("fontsize") );
+            editor.setFontSize( parseInt(this.getAttribute("fontsize")) || 12 );
             editor.setReadOnly( this.hasAttribute("readonly") );
             var session = editor.getSession();
             session.setMode( this.getAttribute("mode") );


### PR DESCRIPTION
Ace ignored the fontsize because it was a string (e.g. `"18"` instead of `18`). Changed that and added a default fontsize when the number is not parseable.