### PR TITLE
Pass custom events through shadow DOM boundaries

### DIFF
--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -86,7 +86,7 @@
                 // container.appendChild(text);
                 container.textContent = this.value;
                 editor = ace.edit(container);
-                this.dispatchEvent(new CustomEvent("editor-ready", {detail: editor}));
+                this.dispatchEvent(new CustomEvent("editor-ready", {bubbles: true, composed: true, detail: editor}));
                 this.editor = editor;
 
                 // inject base editor styles
@@ -95,7 +95,7 @@
                 this.injectTheme('#ace_searchbox');
 
                 editor.getSession().on('change', function(event){
-                    element.dispatchEvent(new CustomEvent("change", {detail: event}));
+                    element.dispatchEvent(new CustomEvent("change", {bubbles: true, composed: true, detail: event}));
                 });
             }
 


### PR DESCRIPTION
Custom events `editor-ready` and `change` were not passed through shadow DOM boundaries so that other components could not catch them.