### PR TITLE
Upgrade for Webcomponents V1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "img"
   ],
   "dependencies": {
-    "webcomponentsjs": "~0.7.10",
+    "webcomponentsjs": "^1.0.0",
     "ace-builds": "~1.2.0"
   },
   "homepage": "https://github.com/Juicy/juicy-ace-editor",

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="http://juicy.github.io/juicy-tile-list/examples/github-markdown.css">
 
     <!-- Importing Web Component's Polyfill -->
-    <script src="//cdn.jsdelivr.net/webcomponentsjs/0.7.24/webcomponents.min.js"></script>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
     <!-- Custom Elements v0->v1 Polyfil -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/document-register-element/1.3.0/document-register-element.js"></script>
 


### PR DESCRIPTION
In order to avoid a conflict on Webcomponents' version when upgrading  `starcounter-layout-html-editor` in https://github.com/Starcounter/starcounter-layout-html-editor/pull/16 , juicy-ace-editor needs to use a WebComponents version higher than 1.

I tested it and everything seems ok.