### PR TITLE
Add `shadow-style` attribute - #28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - npm install bower
   - 'export PATH=$PWD/node_modules/.bin:$PATH'
   - bower install
-node_js: stable
+node_js: 8
 addons:
   firefox: latest
   apt:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Attribute  | Options   | Default | Description
 `tabsize`  | *Boolean* |         | `Session#setTabSize()` at [Ace API](http://ace.c9.io/#nav=api&api=edit_session)
 `readonly` | *Boolean* |         | `Editor#setReadOnly()` at [Ace API](http://ace.c9.io/#nav=api&api=editor)
 `wrapmode` | *Boolean* |         | `Session#setWrapMode()` at [Ace API](http://ace.c9.io/#nav=api&api=edit_session)
-`shadow-style` | *String* |     | CSS selector for a `<style>` element to be injected to Shadow DOM when stamped or attributeChanged
+`shadow-style` | *String* |      | CSS selector for a `<style>` element, from the same (shadow)tree, to be injected to shadow root when stamped or attributeChanged
 
 ## Properties
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Attribute  | Options   | Default | Description
 `tabsize`  | *Boolean* |         | `Session#setTabSize()` at [Ace API](http://ace.c9.io/#nav=api&api=edit_session)
 `readonly` | *Boolean* |         | `Editor#setReadOnly()` at [Ace API](http://ace.c9.io/#nav=api&api=editor)
 `wrapmode` | *Boolean* |         | `Session#setWrapMode()` at [Ace API](http://ace.c9.io/#nav=api&api=edit_session)
+`shadow-style` | *String* |     | CSS selector for a `<style>` element to be injected to Shadow DOM when stamped or attributeChanged
 
 ## Properties
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Or [download as ZIP](https://github.com/juicy/juicy-ace-editor/archive/master.zi
 1. Import Web Components' polyfill (if needed):
 
     ```html
-    <script src="bower_components/webcomponentsjs/webcomponents.min.js"></script>
-    <!-- CE v0 -> v1 -->
-    <script src="document-register-element/document-register-element.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     ```
 
 2. Import Custom Element:
@@ -55,7 +53,7 @@ Or [download as ZIP](https://github.com/juicy/juicy-ace-editor/archive/master.zi
    ```
    <custom-element-demo>
      <template>
-       <script src="../webcomponentsjs/webcomponents.js"></script>
+       <script src="../webcomponentsjs/webcomponents-lite.js"></script>
        <link rel="import" href="juicy-ace-editor.html">
        <next-code-block></next-code-block>
      </template>

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
   ],
   "devDependencies": {
     "polymer": "*",
-    "web-component-tester": "^6.0.1",
-    "document-register-element": "^1.7.0"
+    "web-component-tester": "^6.0.1"
   }
 }

--- a/index.html
+++ b/index.html
@@ -10,8 +10,6 @@
     <script src="../webcomponentsjs/webcomponents.js"></script>
     <!-- or v1 -->
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-    <!-- Custom Elements v0&v1 Polyfil -->
-    <script src="../document-register-element/build/document-register-element.js"></script>
 
     <!-- Importing Custom Elements -->
     <link rel="import" href="juicy-ace-editor.html">

--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
     <link rel="stylesheet" href="http://juicy.github.io/juicy-tile-list/examples/github-markdown.css">
 
     <!-- Importing Web Component's Polyfill -->
-    <!-- v0 with Shadow DOM-->
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <!-- or v1 -->
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
     <!-- Importing Custom Elements -->

--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -163,7 +163,7 @@
                 // non-Ace specific
                 case 'shadow-style':
                     if(oldVal){
-                        this.shadowRoot.querySelector('#'+oldVal).remove();
+                        this.shadowRoot.querySelector(oldVal).remove();
                     }
                     this.injectTheme(newVal);
 
@@ -182,18 +182,10 @@
          * @param {CSSSelector} selector for an element in the same shadow tree or document as `juicy-ace-editor`
          */
         injectTheme(selector){
-            var n = this.getRootNode().querySelector(selector);
-            this.shadowRoot.appendChild(cloneStyle(n));
+            const lightStyle = this.getRootNode().querySelector(selector);
+            this.shadowRoot.appendChild(lightStyle.cloneNode(true));
         }
     };
-
-    //helper function to clone a style
-    function cloneStyle(style) {
-        var s = document.createElement('style');
-        s.id = style.id;
-        s.textContent = style.textContent;
-        return s;
-    }
 
     window.customElements.define('juicy-ace-editor', TomalecAceEditor);
 }(window, document));

--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -6,8 +6,8 @@
     @license MIT
     @author
 -->
-<script src="../ace-builds/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
-<script src="../ace-builds/src-min-noconflict/ext-searchbox.js" type="text/javascript" charset="utf-8"></script>
+<script src="../ace-builds/src-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+<script src="../ace-builds/src-noconflict/ext-searchbox.js" type="text/javascript" charset="utf-8"></script>
 
 <template id="juicy-ace-editor">
     <style>
@@ -54,7 +54,7 @@
         }
         // list of observable attributes
         static get observedAttributes() {
-            return ['theme', 'mode', 'fontsize', 'softtabs', 'tabsize', 'readonly', 'wrapmode'];
+            return ['theme', 'mode', 'fontsize', 'softtabs', 'tabsize', 'readonly', 'wrapmode', 'shadow-style'];
         }
 
         // Fires when an instance of the element is created
@@ -113,6 +113,8 @@
                 session.setUseSoftTabs( this.getAttribute("softtabs") );
                 this.getAttribute("tabsize") && session.setTabSize( this.getAttribute("tabsize") );
                 session.setUseWrapMode( this.hasAttribute("wrapmode") );
+                // non ace specific
+                this.hasAttribute("shadow-style") && this.injectTheme(this.getAttribute('shadow-style'));
 
 
             // Observe input textNode changes
@@ -158,6 +160,12 @@
                 case "wrapmode":
                     this.editor.getSession().setUseWrapMode( newVal !== null );
                     break;
+                // non-Ace specific
+                case 'shadow-style':
+                    if(oldVal){
+                        this.shadowRoot.querySelector('#'+oldVal).remove();
+                    }
+                    this.injectTheme(newVal);
 
             }
         }

--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -177,8 +177,12 @@
             this.container.offsetHeight;
             this.container.style.display='';
         }
-        injectTheme(themeId){
-            var n = document.querySelector(themeId);
+        /**
+         * Injects a style element into juicy-ace-editor's shadow root
+         * @param {CSSSelector} selector for an element in the same shadow tree or document as `juicy-ace-editor`
+         */
+        injectTheme(selector){
+            var n = this.getRootNode().querySelector(selector);
             this.shadowRoot.appendChild(cloneStyle(n));
         }
     };

--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -6,9 +6,6 @@
     <title>&lt;juicy-ace-editor&gt; Kitchen Sink</title>
 
     <!-- Importing Web Component's Polyfill -->
-    <!-- v0 with Shadow DOM-->
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <!-- or v1 -->
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
     <link rel="import" href="../polymer/polymer.html">

--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -5,9 +5,12 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>&lt;juicy-ace-editor&gt; Kitchen Sink</title>
 
-    <script src="//cdn.jsdelivr.net/webcomponentsjs/0.7.24/webcomponents.min.js"></script>
-    <!-- Custom Elements v0->v1 Polyfil -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/document-register-element/1.3.0/document-register-element.js"></script>
+    <!-- Importing Web Component's Polyfill -->
+    <!-- v0 with Shadow DOM-->
+    <script src="../webcomponentsjs/webcomponents.js"></script>
+    <!-- or v1 -->
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
     <link rel="import" href="../polymer/polymer.html">
 
     <link rel="stylesheet" href="http://ace.c9.io/demo/kitchen-sink/styles.css" type="text/css" media="screen" charset="utf-8">
@@ -16,6 +19,7 @@
     <link rel="import" href="juicy-ace-editor.html">
 </head>
 <body>
+<dom-bind>
 <template is="dom-bind">
 <div id="optionsPanel" style="position:absolute;height:100%;width:260px;text-align:right;">
   <a href="http://juicy.github.io/juicy-ace-editor/" style="color:white;text-decoration:none;">
@@ -290,6 +294,7 @@
       wrapmode$="{{wrapmode}}"
       >[[text]]</juicy-ace-editor>
 </template>
+</dom-bind>
 <script type="text" id="editorInnerHTML">Type your code here, to test.
 
     <juicy-ace-editor{{theme}}{{mode}}{{fontsize}}{{readonly}}{{softtabs}}{{tabsize}}{{wrapmode}}
@@ -302,7 +307,7 @@
 
 
 <script type="text/javascript">
-var domBind = document.querySelector("template")
+var domBind = document.querySelector("dom-bind")
 domBind.softtabs= true;
 domBind.mode= "ace/mode/html";
 

--- a/test/custom-theme.html
+++ b/test/custom-theme.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <!-- v0 with Shadow DOM-->
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <!-- or v1 -->
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../juicy-ace-editor.html">
+</head>
+
+<body>
+    <test-fixture id="aceTheme">
+        <template><juicy-ace-editor
+	           theme="ace/theme/dawn"></juicy-ace-editor></template>
+    </test-fixture>
+</body>
+<script>
+    var juicyElement;
+    describe('with `theme` attribute set to `ace/theme/dawn`', function() {
+
+        beforeEach(function(done) {
+            juicyElement = fixture('aceTheme');
+            // wait for theme loaded
+            setTimeout(done, 100);
+        });
+
+        it('should stamp it to its shadowRoot', function() {
+            expect(juicyElement.shadowRoot.querySelector('style#ace-dawn')).to.be.not.null;
+        });
+    });
+</script>
+
+</html>

--- a/test/custom-theme.html
+++ b/test/custom-theme.html
@@ -9,7 +9,6 @@
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../document-register-element/build/document-register-element.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../juicy-ace-editor.html">

--- a/test/custom-theme.html
+++ b/test/custom-theme.html
@@ -5,9 +5,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <!-- v0 with Shadow DOM-->
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
-    <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
@@ -27,7 +24,7 @@
         beforeEach(function(done) {
             juicyElement = fixture('aceTheme');
             // wait for theme loaded
-            setTimeout(done, 100);
+            setTimeout(done, 200);
         });
 
         it('should stamp it to its shadowRoot', function() {

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <!-- if we use WCT suites, it is loaded per suite -->

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@
     <script>
         // Load and run all tests (.html, .js):
         WCT.loadSuites([
-          'spec.html'
+          'spec.html',
+          'custom-theme.html',
+          'shadow-style.html'
         ]);
     </script>
 </body>

--- a/test/shadow-style.html
+++ b/test/shadow-style.html
@@ -9,7 +9,6 @@
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../document-register-element/build/document-register-element.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../juicy-ace-editor.html">

--- a/test/shadow-style.html
+++ b/test/shadow-style.html
@@ -5,9 +5,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <!-- v0 with Shadow DOM-->
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
-    <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 

--- a/test/shadow-style.html
+++ b/test/shadow-style.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <!-- v0 with Shadow DOM-->
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <!-- or v1 -->
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../juicy-ace-editor.html">
+</head>
+
+<body>
+    <test-fixture id="hadmadeStyle">
+        <template><style id="my-theme-id">
+            #juicy-ace-editor-container{
+                font-size: 40px;
+            }
+            .ace-tm div.ace_gutter {
+                font-size: 7px;
+            }
+            </style><juicy-ace-editor
+	           shadow-style="#my-theme-id"></juicy-ace-editor></template>
+    </test-fixture>
+</body>
+<script>
+    var juicyElement;
+    describe('with `shadow-style` attribute set to CSS selector for a custom style element', function() {
+
+        beforeEach(function(done) {
+            juicyElement = fixture('hadmadeStyle')[1];
+            // wait for theme loaded
+            setTimeout(done, 100);
+        });
+
+        it('should stamp it to its shadowRoot and apply styles', function() {
+            expect(juicyElement.shadowRoot.querySelector('style#my-theme-id')).to.be.not.null;
+            expect(window.getComputedStyle(juicyElement.shadowRoot.querySelector('.ace_gutter')).fontSize).to.be.equal('7px');
+        });
+    });
+</script>
+
+</html>

--- a/test/spec.html
+++ b/test/spec.html
@@ -9,7 +9,6 @@
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../document-register-element/build/document-register-element.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../juicy-ace-editor.html">

--- a/test/spec.html
+++ b/test/spec.html
@@ -5,9 +5,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <!-- v0 with Shadow DOM-->
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
-    <!-- or v1 -->
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 


### PR DESCRIPTION
Add `shadow-style` - new attribute to declaratively inject styles to shadow DOM,
add test case for custom Ace themes

fixes #28