### PR TITLE
ignore changes that are set externally

### DIFF
--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -47,9 +47,9 @@
         }
         set value(val){
             if(this.editor){
-                this.ignoreChange = true;
+                this._ignoreChange = true;
                 this.editor.setValue( val );
-                this.ignoreChange = false;
+                this._ignoreChange = false;
             } else {
                 this.textContent = val;
             }
@@ -64,7 +64,7 @@
             // Polyfill ceveat we need to fetch the right context;
             // https://github.com/WebReflection/document-register-element/tree/master#v1-caveat
             self = super(self);
-            this.ignoreChange = false;
+            this._ignoreChange = false;
             // Creates the shadow root
             var shadowRoot;
             if(self.attachShadow && self.getRootNode){
@@ -105,7 +105,7 @@
                 this.injectTheme('#ace_searchbox');
 
                 editor.getSession().on('change', (event) => {
-                    if (!this.ignoreChange) {
+                    if (!this._ignoreChange) {
                         element.dispatchEvent(new CustomEvent("change", {bubbles: true, composed: true, detail: event}));
                     }
                 });

--- a/juicy-ace-editor.html
+++ b/juicy-ace-editor.html
@@ -47,7 +47,9 @@
         }
         set value(val){
             if(this.editor){
+                this.ignoreChange = true;
                 this.editor.setValue( val );
+                this.ignoreChange = false;
             } else {
                 this.textContent = val;
             }
@@ -62,6 +64,7 @@
             // Polyfill ceveat we need to fetch the right context;
             // https://github.com/WebReflection/document-register-element/tree/master#v1-caveat
             self = super(self);
+            this.ignoreChange = false;
             // Creates the shadow root
             var shadowRoot;
             if(self.attachShadow && self.getRootNode){
@@ -101,8 +104,10 @@
                 this.injectTheme('#ace-tm');
                 this.injectTheme('#ace_searchbox');
 
-                editor.getSession().on('change', function(event){
-                    element.dispatchEvent(new CustomEvent("change", {bubbles: true, composed: true, detail: event}));
+                editor.getSession().on('change', (event) => {
+                    if (!this.ignoreChange) {
+                        element.dispatchEvent(new CustomEvent("change", {bubbles: true, composed: true, detail: event}));
+                    }
                 });
             }
 

--- a/test/change-event.html
+++ b/test/change-event.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../juicy-ace-editor.html">
+</head>
+
+<body>
+    <test-fixture id="element">
+        <template><juicy-ace-editor></juicy-ace-editor></template>
+    </test-fixture>
+</body>
+<script>
+    var juicyElement;
+    describe('change event', function() {
+
+        beforeEach(function() {
+            juicyElement = fixture('element');
+        });
+
+        it('should be triggered when the new value comes from ACE setValue method', function() {
+            var content = "some content";
+            var callb = sinon.spy();
+            juicyElement.addEventListener('change', callb);
+            juicyElement.editor.setValue(content);
+            expect(callb).to.be.called;
+        });
+
+        it('should not be triggered when the new value comes from the value setter', function() {
+            var content = "some content";
+            var callb = sinon.spy();
+            juicyElement.addEventListener('change', callb);
+            juicyElement.value = content;
+            expect(callb).to.not.be.called;
+        });
+    });
+</script>
+
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,8 @@
         // Load and run all tests (.html, .js):
         WCT.loadSuites([
           'spec.html',
+          'value.html',
+          'change-event.html',
           'custom-theme.html',
           'shadow-style.html',
           'autosize.html'

--- a/test/value.html
+++ b/test/value.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../juicy-ace-editor.html">
+</head>
+
+<body>
+    <test-fixture id="element">
+        <template><juicy-ace-editor></juicy-ace-editor></template>
+    </test-fixture>
+</body>
+<script>
+    var juicyElement;
+    describe('value property', function() {
+
+        beforeEach(function() {
+            juicyElement = fixture('element');
+        });
+
+        it('should set the editor content', function() {
+            var content = "some content";
+            juicyElement.value = content;
+            expect(juicyElement.editor.getValue()).to.equal(content);
+        });
+    });
+</script>
+
+</html>


### PR DESCRIPTION
changes externally (by setting `juicyAceEditor.value = ".."`) should not result in change event being triggered
this avoids unnecessary notifications to two way data binding libraries such as Polymer
solution is inspired by https://github.com/ajaxorg/ace/issues/503

this is needed to fix Polymer notifications for resetting the value in the editor by a Cancel button (https://github.com/Starcounter/Blending/pull/318#discussion_r229209502)